### PR TITLE
Patches

### DIFF
--- a/commands.lua
+++ b/commands.lua
@@ -597,9 +597,12 @@ basic_robot.commands.keyboard = {
 		end
 	end,
 		
-	set = function(spos,pos,type)
-
+	set = function(data,pos,type)
+		local spos = data.spawnpos;
 		if math.abs(pos.x-spos.x)>10 or math.abs(pos.y-spos.y)>10 or math.abs(pos.z-spos.z)>10 then return false end
+		local owner = data.obj:get_luaentity().owner
+		if minetest.is_protected(pos,owner) then return false end
+
 		local nodename;
 		if type == 0 then
 			nodename = "air"

--- a/commands.lua
+++ b/commands.lua
@@ -804,11 +804,11 @@ basic_robot.commands.machine = {
 		if not add_energy then -- lookup fuel value
 			local fueladd, afterfuel = minetest.get_craft_result({method = "fuel", width = 1, items = {stack}}) 
 			if fueladd.time > 0 then 
-				add_energy = fueladd.time;
+				add_energy = fueladd.time / 40;
 			else
 				return nil, "3: material can not be used as a fuel"
 			end
-			if add_energy>0 then basic_robot.technic.fuels[input] = add_energy/40 end
+			if add_energy>0 then basic_robot.technic.fuels[input] = add_energy end
 		end
 		
 		inv:remove_item("main", stack);

--- a/init.lua
+++ b/init.lua
@@ -276,7 +276,7 @@ function getSandboxEnv (name)
 		
 		keyboard = {
 			get = function() return commands.keyboard.get(name) end,
-			set = function(pos,type) return commands.keyboard.set(basic_robot.data[name].spawnpos,pos,type) end,
+			set = function(pos,type) return commands.keyboard.set(basic_robot.data[name],pos,type) end,
 			read = function(pos) return minetest.get_node(pos).name end,
 		},
 		


### PR DESCRIPTION
add protection check to keyboard set  (Unknown performance impact) . prevents griefing of other's protected areas.

fix energy generated from fuel so that fuel time / 40 is applied earlier rather than only when stored to cache so that first use doesn't use full fuel time.